### PR TITLE
Set up development environment (Docusaurus docs site)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is a [Docusaurus 3](https://docusaurus.io) documentation site (the Zauru ERP user manual, mostly Spanish Markdown under `docs/`). It is a static site generator — there is no backend, database, or auth.
+
+### Services
+
+There is a single service: the Docusaurus site.
+
+- Dev server: `npm start` (serves at http://localhost:3000/, hot-reloads on save). It runs with `--no-open` (see `package.json`), so no browser auto-launch.
+- Production build: `npm run build` (outputs to `build/`), then `npm run serve` to preview the built site.
+- There is no lint or test script defined in `package.json`; `npm run build` is the effective correctness check (it fails on broken links and MDX/Markdown errors).
+
+### Non-obvious notes
+
+- Node version: `.nvmrc` pins Node 22.17.1; any Node 18+ works.
+- Search is powered by Algolia DocSearch (configured in `docusaurus.config.js`). It requires network access to Algolia to return results; if offline, the search modal opens but returns nothing.
+- Standard setup/run instructions live in `README.md`; deployment (Netlify) is documented in `DEPLOY.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this Docusaurus 3 documentation site (Zauru ERP user manual).

- Installs dependencies with `npm install`.
- Verifies the production build (`npm run build`) and dev server (`npm start`).
- Adds `AGENTS.md` with Cursor Cloud specific notes (single static-site service, no backend/lint/test scripts, `npm run build` is the effective check, Algolia search needs network access).

No application code was modified.

## Walkthrough

[zauru_docs_navigation_demo.mp4](https://cursor.com/agents/bc-74e15eaf-42ba-4ada-b161-315f7e108357/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fzauru_docs_navigation_demo.mp4)

Homepage loads, navigation into the Contabilidad article works, and Algolia search returns results for "factura".

[Zauru docs homepage](https://cursor.com/agents/bc-74e15eaf-42ba-4ada-b161-315f7e108357/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Contabilidad documentation article](https://cursor.com/agents/bc-74e15eaf-42ba-4ada-b161-315f7e108357/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontabilidad_article.webp)
[Search results for factura](https://cursor.com/agents/bc-74e15eaf-42ba-4ada-b161-315f7e108357/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_factura.webp)

## Testing

- `npm install` — dependencies installed
- `npm run build` — build succeeded
- `npm start` — dev server serves HTTP 200 at http://localhost:3000/
- Manual GUI test: browse homepage → open article → search (see video)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74e15eaf-42ba-4ada-b161-315f7e108357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74e15eaf-42ba-4ada-b161-315f7e108357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

