### PR TITLE
Fix homepage hero: logo image + dark background match

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -78,8 +78,8 @@
   --ifm-code-background: var(--zauru-paper-2);
   --ifm-code-color: var(--zauru-ink);
 
-  /* Homepage hero — light: paper field, ink type */
-  --zauru-hero-bg: var(--zauru-paper);
+  /* Homepage hero — inherit page background (no separate band) */
+  --zauru-hero-bg: transparent;
   --zauru-hero-text: var(--zauru-ink);
   --zauru-hero-text-soft: var(--zauru-ink-soft);
 }
@@ -130,7 +130,7 @@
   --zauru-shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.45), 0 0 0 1px var(--zauru-gold-tint);
   --zauru-halo-glow: none;
 
-  --zauru-hero-bg: #0c0c0c;
+  --zauru-hero-bg: transparent;
   --zauru-hero-text: #f2f2ee;
   --zauru-hero-text-soft: #b0b0a8;
 }
@@ -294,13 +294,13 @@ a:hover {
   color: var(--zauru-gold);
 }
 .zauru-hero__title {
-  font-family: var(--ifm-font-family-heading);
-  font-weight: 800;
-  font-size: clamp(2.6rem, 8vw, 4rem);
-  line-height: 0.95;
-  letter-spacing: -0.04em;
-  margin: 0 0 12px;
-  color: var(--zauru-hero-text);
+  margin: 0 0 16px;
+  line-height: 0;
+}
+.zauru-hero__logo {
+  display: block;
+  width: clamp(180px, 36vw, 280px);
+  height: auto;
 }
 .zauru-hero__subtitle {
   font-size: 1.05rem;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,8 @@
 import React from "react";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
+import ThemedImage from "@theme/ThemedImage";
 import Icon from "../components/Icon";
 
 const GROUPS = [
@@ -106,6 +108,8 @@ function searchShortcutLabel() {
 
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
+  const logoLight = useBaseUrl("/img/logo.png");
+  const logoDark = useBaseUrl("/img/logo-dark.png");
   const [kbd, setKbd] = React.useState("Ctrl K");
   React.useEffect(() => {
     setKbd(searchShortcutLabel());
@@ -115,7 +119,16 @@ export default function Home() {
     <Layout title={siteConfig.title} description="Manual de usuario de Zauru ERP/CRM">
       <section className="zauru-hero">
         <p className="zauru-hero__eyebrow">Documentación</p>
-        <h1 className="zauru-hero__title">ZAURU</h1>
+        <h1 className="zauru-hero__title">
+          <ThemedImage
+            className="zauru-hero__logo"
+            alt="Zauru"
+            sources={{
+              light: logoLight,
+              dark: logoDark,
+            }}
+          />
+        </h1>
         <p className="zauru-hero__subtitle">
           Encuentra procesos, módulos y reportes del ERP.
         </p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Dark mode hero no longer paints a separate near-black band; it inherits the page background.
- Replaces the typed **ZAURU** title with the same light/dark logo images used in the navbar (`img/logo.png` / `img/logo-dark.png`).

## Changes
- `src/pages/index.js` — hero title uses `ThemedImage` with header logos
- `src/css/custom.css` — hero background set to `transparent`; logo sizing styles

## Test plan
- [ ] Homepage light mode shows the light logo (same as navbar)
- [ ] Homepage dark mode shows the dark logo (same as navbar)
- [ ] Dark mode hero background matches the rest of the page (no darker band)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf56b9f7-12f7-4eee-99c7-ee7fae537b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf56b9f7-12f7-4eee-99c7-ee7fae537b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

