### PR TITLE
Enable gold card accent hover in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -70,7 +70,7 @@
   --ifm-global-shadow-l1: 0 1px 2px rgba(0, 0, 0, 0.06);
   --ifm-global-shadow-l2: 0 4px 12px rgba(0, 0, 0, 0.08);
   --zauru-shadow-card: 0 1px 2px rgba(0, 0, 0, 0.06);
-  --zauru-shadow-card-hover: 0 4px 16px rgba(0, 0, 0, 0.1);
+  --zauru-shadow-card-hover: 4px 4px 0 var(--zauru-gold);
   --zauru-halo-glow: none;
 
   --ifm-menu-link-sublist-icon-filter: invert(0%);
@@ -127,7 +127,11 @@
   --ifm-code-color: var(--zauru-ink);
 
   --zauru-shadow-card: 0 1px 3px rgba(0, 0, 0, 0.4);
-  --zauru-shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.45), 0 0 0 1px var(--zauru-gold-tint);
+  /* Hard gold offset (bottom + right) + soft gold bloom for depth on dark */
+  --zauru-shadow-card-hover:
+    4px 4px 0 var(--zauru-gold),
+    0 10px 28px rgba(0, 0, 0, 0.55),
+    0 0 24px rgba(253, 202, 52, 0.14);
   --zauru-halo-glow: none;
 
   --zauru-hero-bg: transparent;
@@ -338,7 +342,9 @@ a:hover {
   box-shadow: 6px 6px 0 var(--zauru-gold);
 }
 [data-theme="dark"] .zauru-hero__search:hover {
-  box-shadow: 0 0 0 3px var(--zauru-gold-tint);
+  box-shadow:
+    6px 6px 0 var(--zauru-gold),
+    0 0 20px rgba(253, 202, 52, 0.12);
 }
 .zauru-hero__search:focus-visible {
   outline: 2px solid var(--zauru-gold);
@@ -443,17 +449,18 @@ a:hover {
   border-radius: var(--zauru-radius-md);
   color: var(--zauru-ink);
   text-decoration: none;
-  transition: transform 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+  transition: transform 150ms ease, border-color 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
 }
 .zauru-card:hover {
   transform: translateY(-2px);
   border-color: var(--zauru-gold);
-  box-shadow: 4px 4px 0 var(--zauru-gold);
+  box-shadow: var(--zauru-shadow-card-hover);
   color: var(--zauru-ink);
   text-decoration: none;
 }
 [data-theme="dark"] .zauru-card:hover {
-  box-shadow: 0 0 0 3px var(--zauru-gold-tint);
+  background: var(--zauru-card-bg-hover);
+  border-color: var(--zauru-gold);
 }
 .zauru-card:focus-visible {
   outline: 2px solid var(--zauru-gold);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The homepage Carrds already had a hard gold offset shadow on hover in light mode (`4px 4px 0` on the bottom and right). Dark mode was overriding that with a soft ring, so the accent disappeared.

## Changes
- Restore the gold bottom/right offset accent for `.zauru-card:hover` in dark mode
- Layer a subtle gold bloom + depth shadow so the lift feels intentional on dark surfaces
- Slightly lift the card background on dark hover
- Match the same hard-offset language on the hero search hover in dark mode for consistency

## Visual verification

Dark mode hover (gold offset bottom + right + soft bloom):

[Dark mode card hover gold accent](https://cursor.com/agents/bc-019f6933-8549-748e-92e5-067273993520/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdark-mode-hover-verified.png)

Close-up:

[Dark mode card hover closeup](https://cursor.com/agents/bc-019f6933-8549-748e-92e5-067273993520/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdark-card-hover-closeup.png)

Light mode reference:

[Light mode card hover gold accent](https://cursor.com/agents/bc-019f6933-8549-748e-92e5-067273993520/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flight-mode-card-hover-accent.png)

Computed dark hover `box-shadow`:
`rgb(253, 202, 52) 4px 4px 0px`, plus depth and gold bloom layers.

## Test plan
- [x] Open homepage in dark mode
- [x] Hover Carrds and confirm yellow accent appears on bottom + right
- [x] Compare with light mode to confirm the same accent language
- [x] Confirm computed styles apply the hard gold offset in dark mode


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6933-8549-748e-92e5-067273993520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6933-8549-748e-92e5-067273993520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

